### PR TITLE
Enabling git-lfs when checking out the repository.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,8 @@ runs:
   steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        lfs: true
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
This is because some Dockerfiles might assume the presence of artifacts that are stored in git-lfs.

An example of this is `https://github.com/enfuse/koda_turn_yielding` which now stores the model in that repository using git-lfs.