### PR TITLE
chore/update_actions_cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
       run: mkdir -p /tmp/.buildx-cache-${{ inputs.IMAGE_NAME }}
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache-${{ inputs.IMAGE_NAME }}
         key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
       run: mkdir -p /tmp/.buildx-cache-${{ inputs.IMAGE_NAME }}
 
     - name: Cache Docker layers
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache-${{ inputs.IMAGE_NAME }}
         key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
Update the actions/cache from v2 to v3 to resolve: This request has been automatically failed because it uses a deprecated version of actions/cache: v2